### PR TITLE
Update a8picoplus_front.scad

### DIFF
--- a/source/Pico VSCode Project/a8_pico_cart/atari_cart.c
+++ b/source/Pico VSCode Project/a8_pico_cart/atari_cart.c
@@ -1837,6 +1837,16 @@ void __not_in_flash_func(atari_cart_main)()
     while (1) {
         int cmd = emulate_boot_rom(atrMode);
 
+		// Erase screen when the first command is executed
+		static bool screen_need_erase = true;
+		if (screen_need_erase) {
+			// Clear framebuffer
+			memset(cart_ram, 0, sizeof(cart_ram));
+			// Show cleared framebuffer
+			show_artwork(cart_ram);
+			screen_need_erase = false;
+		}
+
         // OPEN ITEM n
         if (cmd == CART_CMD_OPEN_ITEM) 
         {


### PR DESCRIPTION
Screen clear will happen one time, after first cart request happens.
This ensures proper cart operation even if there is an issue with display